### PR TITLE
Push back to GitHub CLI v2.2.0

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,10 +20,9 @@ jobs:
 
       - name: Install GitHub CLI
         run: |
-          sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-          sudo apt-add-repository https://cli.github.com/packages
-          sudo apt update
-          sudo apt install gh
+            curl -LO https://github.com/cli/cli/releases/download/v2.2.0/gh_2.2.0_linux_amd64.deb
+            sudo dpkg -i gh_2.2.0_linux_amd64.deb
+
 
       - name: Authenticate with GitHub CLI
         run: echo ${{ secrets.GITHUB_TOKEN }} | gh auth login --with-token


### PR DESCRIPTION
Latest Ubuntu GH CLI is not compatible with Ubuntu latest. This fixes that.

Fixes #25 